### PR TITLE
Timeline and VideoEditor

### DIFF
--- a/css/lexgui.css
+++ b/css/lexgui.css
@@ -3723,6 +3723,11 @@ meter:-moz-meter-sub-sub-optimum::-moz-meter-bar {
     margin: 0px;
 }
 
+.lextimeline .lextree .lextreeitem.selected {
+    background-color: var(--primary);
+    color: var(--primary-foreground);
+}
+
 .lextimeline .lextree ul {
     margin: 0;
     padding-bottom: 0px;

--- a/docs/extensions/timeline.html
+++ b/docs/extensions/timeline.html
@@ -105,10 +105,6 @@
         ["itemsRemoved", "Array of Numbers"],
     ] );
 
-    // docMaker.classMethod( "onTrackTreeEvent", `Triggered after an event of the tree in the left panel, which displays the visible tracks.`, [
-    //     ["event", "LX.TreeEvent"]
-    // ] );
-
     docMaker.classMethod( "onSetTrackSelection", `Triggered after calling ${docMaker.iCode("setTrackSelection")}.`, [
         ["track", "Object"],
         ["previousState", "Boolean"],
@@ -197,6 +193,11 @@
     docMaker.classMethod( ".setTrackHeight", "Set track height, in pixels.", [
         ["height", "Number"]
     ], "" );
+
+    docMaker.classMethod( ".setTrackTreeEventListener", `Set callbacks to specific events of the tracks tree.`, [
+        ["type", "String LX.NodeTree event"],
+        ["callback", "fn (event) => void"]
+    ] );
 
     docMaker.classMethod( ".getVisibleItems", `Returns a reference to the track tree elements. Each element has a ${docMaker.iCode(".treeData.trackData")}.`, [ ], "HTMLCollection" );
 

--- a/docs/extensions/video-editor.html
+++ b/docs/extensions/video-editor.html
@@ -49,16 +49,32 @@
     ]);
 
     docMaker.header("VideoEditor", "h3");
+    docMaker.classCtor( "class LX.VideoEditor", [
+        ["area", "LX.Area"],
+        ["options", "Object"]
+    ] );
+    docMaker.lineBreak();
     docMaker.paragraph(`High-level editor that embeds video playback with trimming and optional cropping overlay. Provides playback controls, time synchronization, and crop management.
-    It has to be appended to an existing area. It means that it can be created anywhere in the document window (e.g. dialogs, panels, areas, etc.), since to create an area it's as easy as instancing a new one.
-    When creating it, you can use different options to adapt the editor to your needs:` );
-    docMaker.codeBulletList([
-        ["src", "String", "Video URL"],
-        ["video", "HTMLVideoElement", "Video native element"],
-        ["crop", "Boolean", "Enable crop functionality"],
-        ["controls", "Boolean", "Enable playing ontrols for the video"],
-        ["handleStyle", "Object", "Style properties for the resize handles"]
-    ]);
+    It has to be appended to an existing area. It means that it can be created anywhere in the document window (e.g. dialogs, panels, areas, etc.), since to create an area it's as easy as instancing a new one.` );
+    docMaker.lineBreak();
+    {
+        const area = new LX.Area( { skipAppend: true, height: "auto", className: "mb-6" } );
+        const panel = area.addPanel();
+        content.appendChild( area.root );
+        panel.addTable( null, {
+            head: [ "Option", "Type", "Description", "Default" ],
+            body: [
+                ["src", "String", "Video URL", "-"],
+                ["video", "HTMLVideoElement", "Video native element", "-"],
+                ["crop", "Boolean", "Enable crop functionality", "-"],
+                ["handleStyle", "Object", "Style properties for the resize handles", "-"],
+                ["controls", "Boolean", "Enable playing controls for the video", "-"],
+                ["controlsLayout", "Object", `See ${docMaker.iCode( "createControls" )}`, "-"],
+            ].map( v => {
+                return [ docMaker.iCode( v[ 0 ], "table" ), docMaker.iCode( v[ 1 ], "table desc" ), v[ 2 ], v[ 3 ] != "—" ? docMaker.iCode( v[ 3 ], "table desc" ) : v[ 3 ] ];
+            } )
+        }, {});
+    }
 
     docMaker.header("Statics", "h4");
 
@@ -77,29 +93,41 @@
 
     docMaker.header("Methods", "h4");
 
-    docMaker.codeBulletList([
-        ["showCropArea()", "Displays the crop overlay and masks the underlying video."],
-        ["hideCropArea()", "Hides the crop overlay and clears masking."],
-        ["showControls() / hideControls()", "Toggle the visibility of the playback/trimming controls."],
-        ["createControls(options: object)", `Generates all buttons and timebar, and displays them following a layout. ${docMaker.iCode("options")} may have:`],
-        [
-          ["null", `If ${docMaker.iCode("options")} is not provided, the VideoEditor constructor's options will be used.`],
-          ["controlsLayout", `fn or integer[0,1]`, `A number will create a predefined layout. When a function, it must create the areas where the buttons and timebar (see ${docMaker.iCode("controlsComponents")}) will be and attach them. The function must also implement the ${docMaker.iCode("resizeControls")} function.`],
-        ],
-        ["resize()", "Triggered when parent area resizes. Call this functions to force a resize."],
-        ["resizeVideo()", "Triggered in resize. Call this functions to force a resize."],
-        ["resizeControls()", `Triggered in resize. Call this functions to force a resize. See ${docMaker.iCode("createControls")}.`],
-        ["resizeCropArea(sx: number, sy: number, isNormalized: boolean = true)", "Adjusts crop size based on pixel or normalized sizes. Sizes are restricted by the video size and current crop area position."],
-        ["moveCropArea(x: number, y: number, isNormalized: boolean = true)", "Adjusts crop location based on pixel or normalized coordinates. The position is restricted by the video size and current crop area size."],
-        ["setCropAreaHandles(flags: number)", `Sets which resize handles to display based on flags. Use the ${docMaker.iCode(`|`)} operator to enable multiple handles (e.g. ${docMaker.iCode(`CROP_HANDLE_L | CROP_HANDLE_B`)})`],
-        ["getStartTime()", "Returns current trim start time."],
-        ["getEndTime()", "Returns current trim end time."],
-        ["getTrimedTimes()", "Returns both start and end as `{ start, end }`."],
-        ["getCroppedArea()", "Returns the DOM rect of the crop overlay."],
-        ["stopUpdates()", "Stops the internal animation frame loop."],
-        ["unbind()", "Tears down listeners, pauses video, and clears playback state."],
-    ]);
+    docMaker.classMethod( "showCropArea", "Displays the crop overlay and masks the underlying video.", [] );
+    docMaker.classMethod( "hideCropArea", "Hides the crop overlay and clears masking." , [] );
+    docMaker.classMethod( "showControls", "Display the playback/trimming controls.", [] );
+    docMaker.classMethod( "hideControls", "Hides the playback/trimming controls.", [] );
+    
+    docMaker.classMethod( "createControls", `Generates all buttons and timebar, and displays them following a layout. ${docMaker.iCode("layoutOptions")} may have:`, [["layoutOptions", "object"]] );
+    {
+        const area = new LX.Area( { skipAppend: true, height: "auto", className: "mb-6" } );
+        const panel = area.addPanel();
+        content.appendChild( area.root );
+        panel.addTable( null, {
+            head: [ "Option", "Type", "Description", "Default" ],
+            body: [
+                ["type", `Number or Function`, `A number (0 or 1) will create a predefined layout. When a function, it must create the areas where the buttons and timebar (see ${docMaker.iCode("controlsComponents")}) will be and attach them. The function must also implement the ${docMaker.iCode("resizeControls")} function.`, `0`],
+                ["size", `CSS Height value`, `Height of the controls area. The remaining will be set to the video area`, `85%`],
+                ["l1TimelineHeight", `CSS Height value`, `(Predefined layout 1) Height of the trimming area. The remaining will be set to the rest of the controls area`, `50%`],
+            ].map( v => {
+                return [ docMaker.iCode( v[ 0 ], "table" ), docMaker.iCode( v[ 1 ], "table desc" ), v[ 2 ], v[ 3 ] != "—" ? docMaker.iCode( v[ 3 ], "table desc" ) : v[ 3 ] ];
+            } )
+        }, {});
+    }
+    docMaker.classMethod( "resize", "Triggered when parent area resizes. Call this functions to force a resize.", [] );
+    docMaker.classMethod( "resizeVideo", "Triggered in resize. Call this functions to force a resize.", [] );
+    docMaker.classMethod( "resizeControls", `Triggered in resize. Call this functions to force a resize. See ${docMaker.iCode("createControls")}.`, [] );
+    docMaker.classMethod( "resizeCropArea", "Adjusts crop size based on pixel or normalized sizes. Sizes are restricted by the video size and current crop area position.", [["sx", "number"],["sy", "number"],["isNormalized", "boolean = true"]] );
+    docMaker.classMethod( "moveCropArea","Adjusts crop location based on pixel or normalized coordinates. The position is restricted by the video size and current crop area size.", [["x", "number"],["y", "number"],["isNormalized", "boolean = true"]] );
+    docMaker.classMethod( "setCropAreaHandles",  `Sets which resize handles to display based on flags. Use the ${docMaker.iCode(`|`)} operator to enable multiple handles (e.g. ${docMaker.iCode(`CROP_HANDLE_L | CROP_HANDLE_B`)})`, [["flags", "Number"]] );
+    docMaker.classMethod( "getStartTime", "Returns current trim start time.", [] );
+    docMaker.classMethod( "getEndTime", "Returns current trim end time.", [] );
+    docMaker.classMethod( "getTrimedTimes", "Returns both start and end as `{ start, end }`.", [] );
+    docMaker.classMethod( "getCroppedArea", "Returns the DOM rect of the crop overlay.", [] );
+    docMaker.classMethod( "stopUpdates", "Stops the internal animation frame loop.", [] );
+    docMaker.classMethod( "unbind", "Tears down listeners, pauses video, and clears playback state.", [] );
 
+ 
     docMaker.header("Callbacks / Hooks", "h3");
     docMaker.paragraph("You can assign handlers to respond to user interaction and internal state changes:");
     docMaker.codeBulletList([

--- a/docs/extensions/video-editor.html
+++ b/docs/extensions/video-editor.html
@@ -107,7 +107,7 @@
             head: [ "Option", "Type", "Description", "Default" ],
             body: [
                 ["type", `Number or Function`, `A number (0 or 1) will create a predefined layout. When a function, it must create the areas where the buttons and timebar (see ${docMaker.iCode("controlsComponents")}) will be and attach them. The function must also implement the ${docMaker.iCode("resizeControls")} function.`, `0`],
-                ["size", `CSS Height value`, `Height of the controls area. The remaining will be set to the video area`, `85%`],
+                ["size", `CSS Height value`, `Height of the controls area. The remaining will be set to the video area`, `15%`],
                 ["l1TimelineHeight", `CSS Height value`, `(Predefined layout 1) Height of the trimming area. The remaining will be set to the rest of the controls area`, `50%`],
             ].map( v => {
                 return [ docMaker.iCode( v[ 0 ], "table" ), docMaker.iCode( v[ 1 ], "table desc" ), v[ 2 ], v[ 3 ] != "—" ? docMaker.iCode( v[ 3 ], "table desc" ) : v[ 3 ] ];

--- a/docs/extensions/video-editor.html
+++ b/docs/extensions/video-editor.html
@@ -107,7 +107,7 @@
             head: [ "Option", "Type", "Description", "Default" ],
             body: [
                 ["type", `Number or Function`, `A number (0 or 1) will create a predefined layout. When a function, it must create the areas where the buttons and timebar (see ${docMaker.iCode("controlsComponents")}) will be and attach them. The function must also implement the ${docMaker.iCode("resizeControls")} function.`, `0`],
-                ["size", `CSS Height value`, `Height of the controls area. The remaining will be set to the video area`, `15%`],
+                ["height", `CSS Height value`, `Height of the controls area. The remaining will be set to the video area`, `15%`],
                 ["l1TimelineHeight", `CSS Height value`, `(Predefined layout 1) Height of the trimming area. The remaining will be set to the rest of the controls area`, `50%`],
             ].map( v => {
                 return [ docMaker.iCode( v[ 0 ], "table" ), docMaker.iCode( v[ 1 ], "table desc" ), v[ 2 ], v[ 3 ] != "—" ? docMaker.iCode( v[ 3 ], "table desc" ) : v[ 3 ] ];

--- a/src/extensions/Timeline.ts
+++ b/src/extensions/Timeline.ts
@@ -32,7 +32,6 @@ export abstract class Timeline
     static TRACK_COLOR_SECONDARY: string;
     static TRACK_COLOR_TERTIARY: string;
     static TRACK_SELECTED: string;
-    static TRACK_SELECTED_LIGHT: string;
     static FONT: string;
     static FONT_COLOR_PRIMARY: string;
     static FONT_COLOR_TERTIARY: string;
@@ -239,6 +238,7 @@ export abstract class Timeline
             Timeline.TRACK_COLOR_PRIMARY = LX.getCSSVariable( 'card' );
             Timeline.TRACK_COLOR_SECONDARY = LX.getCSSVariable( 'secondary' );
             Timeline.TRACK_COLOR_TERTIARY = LX.getCSSVariable( 'accent' );
+            Timeline.TRACK_SELECTED = LX.getCSSVariable( 'primary' );
             Timeline.FONT = LX.getCSSVariable( 'global-font' );
             Timeline.FONT_COLOR_PRIMARY = LX.getCSSVariable( 'foreground' );
             Timeline.FONT_COLOR_TERTIARY = LX.getCSSVariable( 'primary' );
@@ -250,6 +250,8 @@ export abstract class Timeline
             Timeline.KEYFRAME_COLOR_LOCK = LX.getCSSVariable( 'lxTimeline-keyframe-locked' );
             Timeline.KEYFRAME_COLOR_EDITED = LX.getCSSVariable( 'lxTimeline-keyframe-edited' );
             Timeline.KEYFRAME_COLOR_INACTIVE = LX.getCSSVariable( 'lxTimeline-keyframe-inactive' );
+            Timeline.TIME_MARKER_COLOR = LX.getCSSVariable( 'primary' );
+            Timeline.TIME_MARKER_COLOR_TEXT = LX.getCSSVariable('primary-foreground');
         }
 
         this.updateTheme = updateTheme.bind( this );
@@ -724,7 +726,7 @@ export abstract class Timeline
         ctx.fillStyle = Timeline.TRACK_COLOR_SECONDARY;
 
         const rectsOffset = this.currentScrollInPixels % line_height;
-        const blackOrWhite = 1 - Math.floor( this.currentScrollInPixels / line_height ) % 2;
+        const blackOrWhite = Math.floor( this.currentScrollInPixels / line_height ) % 2;
         for ( let i = blackOrWhite; i <= max_tracks; i += 2 )
         {
             ctx.fillRect( 0, treeOffset - rectsOffset + i * line_height, w, line_height );
@@ -761,8 +763,9 @@ export abstract class Timeline
         const h = ctx.canvas.height;
 
         const scrollableHeight = this.trackTreesComponent.root.scrollHeight;
+        // hack: get 'ul' start pos to know when tracks start
         // tree has gaps of 0.25rem (4px ) inbetween entries but not in the beginning nor ending. Move half gap upwards.
-        const treeOffset = this.lastTrackTreesComponentOffset = this.trackTreesComponent.innerTree.domEl.offsetTop
+        const treeOffset = this.lastTrackTreesComponentOffset = this.trackTreesComponent.innerTree.domEl.children[0].offsetTop
             - this.canvas.offsetTop - 2;
 
         // zoom
@@ -1698,14 +1701,13 @@ Timeline.BACKGROUND_COLOR = LX.getCSSVariable( 'background-blur' );
 Timeline.TRACK_COLOR_PRIMARY = LX.getCSSVariable( 'card' );
 Timeline.TRACK_COLOR_SECONDARY = LX.getCSSVariable( 'secondary' );
 Timeline.TRACK_COLOR_TERTIARY = LX.getCSSVariable( 'accent' );
-Timeline.TRACK_SELECTED = LX.getCSSVariable( 'color-blue-600' );
-Timeline.TRACK_SELECTED_LIGHT = LX.getCSSVariable( 'color-blue-400' );
+Timeline.TRACK_SELECTED = LX.getCSSVariable( 'primary' );
 Timeline.FONT = LX.getCSSVariable( 'global-font' );
 Timeline.FONT_COLOR_PRIMARY = LX.getCSSVariable( 'foreground' );
 Timeline.FONT_COLOR_TERTIARY = LX.getCSSVariable( 'primary' );
 Timeline.FONT_COLOR_QUATERNARY = LX.getCSSVariable( 'muted-foreground' );
-Timeline.TIME_MARKER_COLOR = LX.getCSSVariable( 'color-blue-600' );
-Timeline.TIME_MARKER_COLOR_TEXT = '#ffffff';
+Timeline.TIME_MARKER_COLOR = LX.getCSSVariable( 'primary' );
+Timeline.TIME_MARKER_COLOR_TEXT = LX.getCSSVariable('primary-foreground');
 
 LX.setCSSVariable( 'lxTimeline-keyframe', 'light-dark(#2d69da,#2d69da )' );
 LX.setCSSVariable( 'lxTimeline-keyframe-selected', 'light-dark(#f5c700,#fafa14)' );
@@ -2689,7 +2691,7 @@ export class KeyFramesTimeline extends Timeline
         if ( track.isSelected )
         {
             ctx.globalAlpha = 0.2;
-            ctx.fillStyle = Timeline.TRACK_SELECTED_LIGHT;
+            ctx.fillStyle = Timeline.TRACK_SELECTED;
             ctx.fillRect( 0, 0, ctx.canvas.width, trackHeight );
         }
 
@@ -4568,7 +4570,7 @@ export class ClipsTimeline extends Timeline
     {
         // Fill track background if it's selected
         ctx.globalAlpha = 0.2;
-        ctx.fillStyle = Timeline.TRACK_SELECTED_LIGHT;
+        ctx.fillStyle = Timeline.TRACK_SELECTED;
         if ( track.isSelected )
         {
             ctx.fillRect( 0, y, ctx.canvas.width, trackHeight );

--- a/src/extensions/Timeline.ts
+++ b/src/extensions/Timeline.ts
@@ -251,7 +251,7 @@ export abstract class Timeline
             Timeline.KEYFRAME_COLOR_EDITED = LX.getCSSVariable( 'lxTimeline-keyframe-edited' );
             Timeline.KEYFRAME_COLOR_INACTIVE = LX.getCSSVariable( 'lxTimeline-keyframe-inactive' );
             Timeline.TIME_MARKER_COLOR = LX.getCSSVariable( 'primary' );
-            Timeline.TIME_MARKER_COLOR_TEXT = LX.getCSSVariable('primary-foreground');
+            Timeline.TIME_MARKER_COLOR_TEXT = LX.getCSSVariable( 'primary-foreground' );
         }
 
         this.updateTheme = updateTheme.bind( this );
@@ -1707,7 +1707,7 @@ Timeline.FONT_COLOR_PRIMARY = LX.getCSSVariable( 'foreground' );
 Timeline.FONT_COLOR_TERTIARY = LX.getCSSVariable( 'primary' );
 Timeline.FONT_COLOR_QUATERNARY = LX.getCSSVariable( 'muted-foreground' );
 Timeline.TIME_MARKER_COLOR = LX.getCSSVariable( 'primary' );
-Timeline.TIME_MARKER_COLOR_TEXT = LX.getCSSVariable('primary-foreground');
+Timeline.TIME_MARKER_COLOR_TEXT = LX.getCSSVariable( 'primary-foreground' );
 
 LX.setCSSVariable( 'lxTimeline-keyframe', 'light-dark(#2d69da,#2d69da )' );
 LX.setCSSVariable( 'lxTimeline-keyframe-selected', 'light-dark(#f5c700,#fafa14)' );

--- a/src/extensions/Timeline.ts
+++ b/src/extensions/Timeline.ts
@@ -495,6 +495,11 @@ export abstract class Timeline
             }
         } );
 
+        // reset all tree events to the new tree
+        for( let name in this.trackTreesEvents){
+            this.setTrackTreeEventListener( name, this.trackTreesEvents[name] );
+        }
+
         const that = this;
         this.trackTreesComponent.innerTree._refresh = this.trackTreesComponent.innerTree.refresh;
         this.trackTreesComponent.innerTree.refresh = function( newData: any, selectedId: Nullable<string> )

--- a/src/extensions/VideoEditor.ts
+++ b/src/extensions/VideoEditor.ts
@@ -535,6 +535,7 @@ export class VideoEditor
     constructor( area: typeof Area, options: any = {} )
     {
         this.options = options ?? {};
+        const controlsOptions = this.options.controlsLayout ?? {};
         this.speed = options.speed ?? this.speed;
         this.mainArea = area;
 
@@ -548,7 +549,9 @@ export class VideoEditor
         }
         else
         {
-            [ videoArea, controlsArea ] = area.split( { type: 'vertical', sizes: [ '85%', null ], minimizable: false, resize: false } );
+            [ videoArea, controlsArea ] = area.split( { type: 'vertical',
+                sizes: [ controlsOptions.controlsSize ? `calc(100% - ${controlsOptions.controlsSize})` : '85%', null ], minimizable: false,
+                resize: false } );
         }
 
         controlsArea.root.classList.add( 'lexconstrolsarea' );
@@ -735,10 +738,14 @@ export class VideoEditor
         this.onChangeEnd = null;
     }
 
-    createControls( options: any = null )
+    createControls( controlsLayoutOptions: any = null )
     {
         const controlsArea = this.controlsArea;
-        options = options ?? this.options;
+        if ( controlsLayoutOptions )
+        {
+            this.options.controlsLayout = controlsLayoutOptions;
+        }
+        const controlsOptions = this.options.controlsLayout ?? {};
 
         // clear area. Signals are not cleared !!! (not a problem if there are no signals)
         while ( controlsArea.root.children.length )
@@ -815,11 +822,11 @@ export class VideoEditor
             selected: this.loop } );
 
         let timeBarArea = null;
-        if ( typeof ( options.controlsLayout ) == 'function' )
+        if ( typeof ( controlsOptions.type ) == 'function' )
         {
-            timeBarArea = options.controlsLayout;
+            timeBarArea = controlsOptions.type;
         }
-        else if ( options.controlsLayout == 1 )
+        else if ( controlsOptions.type == 1 )
         {
             timeBarArea = this._createControlsLayout_1();
         }
@@ -860,9 +867,11 @@ export class VideoEditor
     _createControlsLayout_1()
     {
         const controlsArea = this.controlsArea;
+        const options = this.options.controlsLayout ?? {};
 
         // Create playing timeline area and attach panels
-        let [ timeBarArea, bottomArea ] = controlsArea.split( { type: 'vertical', sizes: [ '50%', null ], minimizable: false, resize: false } );
+        let [ timeBarArea, bottomArea ] = controlsArea.split( { type: 'vertical', sizes: [ options.l1TimelineHeight ?? '50%', null ],
+            minimizable: false, resize: false } );
 
         bottomArea.root.classList.add( 'relative' );
 

--- a/src/extensions/VideoEditor.ts
+++ b/src/extensions/VideoEditor.ts
@@ -550,7 +550,7 @@ export class VideoEditor
         else
         {
             [ videoArea, controlsArea ] = area.split( { type: 'vertical',
-                sizes: [ controlsOptions.controlsSize ? `calc(100% - ${controlsOptions.controlsSize})` : '85%', null ], minimizable: false,
+                sizes: [ controlsOptions.height ? `calc(100% - ${controlsOptions.height})` : '85%', null ], minimizable: false,
                 resize: false } );
         }
 


### PR DESCRIPTION
Which version number to update: 0.1.0
- A couple of functions and parameters have changed. 

Timeline:
- Selected Tree entries now use the primary color
- `onTrackTreeEvent` has been removed
- `setTrackTreeEventListener` has been added. It sets a specific callback for the tree component

VideoEditor
-  the `controlsLayout` of the constructor now expects an object that may contain `type`, `height` and/or `l1TimelineHeight` 